### PR TITLE
Fix data to be string instead of bytestring for Python3

### DIFF
--- a/confluence_tool/cli/cli.py
+++ b/confluence_tool/cli/cli.py
@@ -188,6 +188,7 @@ def _handle_method(method, config, data=None, json=None):
         if config.get('stream'):
             _len = 0
             for data in result.iter_content(chunk_size=1024*1024):
+                data = data.decode("utf-8")
                 outstream.write(data)
 
                 _len += len(data)


### PR DESCRIPTION
It seems that there is still an issue when using stream parameter for ct get command. Variable **data** is an bytestring but needs to be string for write function.